### PR TITLE
message-buffer: make the strings be null terminated

### DIFF
--- a/src/message-buffer.cpp
+++ b/src/message-buffer.cpp
@@ -12,8 +12,8 @@ void Message::save(const nlohmann::json& json)
 {
     T value = json;
     if (m_currSize + sizeof(T) <= m_maxSize) {
-    std::memcpy(m_message.data() + m_currSize, &value, sizeof(T));
-    m_currSize += sizeof(T);
+        std::memcpy(m_message.data() + m_currSize, &value, sizeof(T));
+        m_currSize += sizeof(T);
     }
 }
 
@@ -22,8 +22,8 @@ void Message::save<std::string>(const nlohmann::json& json)
 {
     std::string value = json;
     if (m_currSize + value.size() <= m_maxSize) {
-    std::memcpy(m_message.data() + m_currSize, value.data(), value.size());
-    m_currSize += value.size();
+        std::memcpy(m_message.data() + m_currSize, value.data(), value.size() + 1);
+        m_currSize += value.size() + 1;
     }
 }
 
@@ -86,7 +86,7 @@ void MessagesBuffer::read()
         l.try_lock_for(std::chrono::milliseconds(30));
 
         if (it != m_messages.end()) {
-            //mostrar conteudo
+            // mostrar conteudo
             nlohmann::json jsonVector;
             it->second >> jsonVector;
             std::cout << static_cast<int>(it->first) << " : " << jsonVector << std::endl;


### PR DESCRIPTION
<!--PS: 🇧🇷/🇬🇧 It's ok to write your PR in portuguese 😃-->

## What type of PR is this? (check all applicable)
- [ ] ✨ Feature
- [X] 🐞 Bug Correction
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

# Changes:
<!-- Describe the main changes and the **expected behaviour** (if aplicable) -->
Antes as strings não estavam tendo o byte null no final, o que impossibilita a decodificação. Por isso, ele deve ser colocado no final de cada string

