### PR TITLE
message-buffer: add id to the beginning of the array

### DIFF
--- a/src/message-buffer.cpp
+++ b/src/message-buffer.cpp
@@ -106,6 +106,8 @@ void MessagesBuffer::write(std::uint8_t id, const nlohmann::json& message)
 
     constexpr int numBytes = 90;
     Message messageObj(numBytes);
+
+    messageObj.save<std::int8_t>(id);
     messageObj << message;
 
     m_messages.insert(std::make_pair(id, messageObj));

--- a/src/message-buffer.hpp
+++ b/src/message-buffer.hpp
@@ -15,11 +15,12 @@ private:
     std::size_t m_currSize;
 
     void write(const nlohmann::json& json);
-    template <typename T>
-    void save(const nlohmann::json& json);
 
 public:
     explicit Message(std::size_t maxSize);
+
+    template <typename T>
+    void save(const nlohmann::json& json);
 
     void operator<<(const nlohmann::json& json);
     void operator>>(nlohmann::json& json);


### PR DESCRIPTION
<!--PS: 🇧🇷/🇬🇧 It's ok to write your PR in portuguese 😃-->

## What type of PR is this? (check all applicable)
- [X] ✨ Feature
- [ ] 🐞 Bug Correction
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

# Changes:
<!-- Describe the main changes and the **expected behaviour** (if aplicable) -->
Adiciona o id da equipe no inicio do array, assim possibilitando a separação das mensagens