### PR TITLE
message-buffer: fix: change getCurrMessage() behavior

### DIFF
--- a/src/message-buffer.hpp
+++ b/src/message-buffer.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <chrono>
+#include <deque>
 #include <iostream>
-#include <map>
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <string>
@@ -18,6 +18,7 @@ private:
 
 public:
     explicit Message(std::size_t maxSize);
+    Message() = default;
 
     template <typename T>
     void save(const nlohmann::json& json);
@@ -29,18 +30,12 @@ public:
 class MessagesBuffer {
 private:
     std::timed_mutex m_mutex;
-    std::unique_ptr<std::thread> m_thread;
 
-    std::map<std::uint8_t, Message> m_messages;
-    int delay;
-
-    Message m_currMessage;
-
-    void read();
+    static constexpr int MAX_ID = 256;
+    std::array<Message, MAX_ID> m_messages;
+    std::deque<std::uint8_t> m_currIndex;
 
 public:
-    explicit MessagesBuffer(int m_delay);
-
     auto getCurrMessage() -> nlohmann::json;
     void write(std::uint8_t id, const nlohmann::json& message);
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -21,7 +21,6 @@ public:
         : RoutineService { "serverd" }
         , m_host { host }
         , m_port { port }
-        , m_buffer { buffer_size }
     {
     }
 
@@ -53,12 +52,12 @@ public:
             res.set_content(error, "text/plain");
         });
 
-        m_svr.set_exception_handler([](const httplib::Request& req, httplib::Response& res, std::exception& e) {
+        m_svr.set_exception_handler([](const httplib::Request&, httplib::Response& res, std::exception& e) {
             std::cout << e.what() << std::endl;
             res.set_content("exception raised", "text/plain");
         });
 
-        DBusHandler::registerMethod(m_requestPath, [&](nlohmann::json req) {
+        DBusHandler::registerMethod(m_requestPath, [&](nlohmann::json) {
             return m_buffer.getCurrMessage();
         });
     }


### PR DESCRIPTION
<!--PS: 🇧🇷/🇬🇧 It's ok to write your PR in portuguese 😃-->

## What type of PR is this? (check all applicable)
- [ ] ✨ Feature
- [X] 🐞 Bug Correction
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

# Changes:
<!-- Describe the main changes and the **expected behaviour** (if aplicable) -->
On the previous way m_currMessage pointed to the latest message sent to
the server, now it's point to the first message sent that was not
already read.

